### PR TITLE
fix bufferoverflow

### DIFF
--- a/tap2tzx.c
+++ b/tap2tzx.c
@@ -40,7 +40,7 @@ void ChangeFileExtension(char *str, char *ext)
     // Changes the File Extension of String *str to *ext
     int n, m;
     n = strlen(str);
-    while (str[n] != '.')
+    while (str[n] != '.' && n>0)
         n--;
     n++;
     str[n] = 0;


### PR DESCRIPTION
There is a pointer problem in the code so it will coredump if "." is missing the filename.

Original version:

> $ ./tap2tzx readme
> 
> ZXTape Utilities - TAP to TZX Converter v0.12b
> Segmentation fault (core dumped)

With this fix:

> $ ./tap2tzx readme
> 
> ZXTape Utilities - TAP to TZX Converter v0.12b
> 
> -- Error: Input file not found!
> 
> 
> 